### PR TITLE
Configure clock status decoder to handle snake case

### DIFF
--- a/Clock/Networking/ClockAPI.swift
+++ b/Clock/Networking/ClockAPI.swift
@@ -37,7 +37,9 @@ final class ClockAPI {
     func fetchStatus() async throws -> ClockStatus {
         let url = baseURL.appendingPathComponent("status")
         let (data, _) = try await URLSession.shared.data(from: url)
-        return try JSONDecoder().decode(ClockStatus.self, from: data)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(ClockStatus.self, from: data)
     }
 }
 


### PR DESCRIPTION
## Summary
- configure the decoder used by `ClockAPI.fetchStatus()` to convert snake_case JSON keys when loading `ClockStatus`

## Testing
- `xcodebuild -list` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb981e27ac8330be9f1ae09821291d