### PR TITLE
Rename status metadata to camelCase

### DIFF
--- a/Clock/Models/ClockStatus.swift
+++ b/Clock/Models/ClockStatus.swift
@@ -23,6 +23,32 @@ struct ClockStatus: Codable {
     var timeStamp: String?
     // Extras returned by /status
     var serverTime: Int?
-    var api_version: String?
-    var connection_protocol: String?
+    var apiVersion: String?
+    var connectionProtocol: String?
+
+    enum CodingKeys: String, CodingKey {
+        case minutes
+        case seconds
+        case currentRound
+        case totalRounds
+        case isRunning
+        case isPaused
+        case elapsedMinutes
+        case elapsedSeconds
+        case isBetweenRounds
+        case betweenRoundsMinutes
+        case betweenRoundsSeconds
+        case betweenRoundsEnabled
+        case betweenRoundsTime
+        case warningLeadTime
+        case warningSoundPath
+        case endSoundPath
+        case ntpSyncEnabled
+        case ntpOffset
+        case endTime
+        case timeStamp
+        case serverTime
+        case apiVersion = "api_version"
+        case connectionProtocol = "connection_protocol"
+    }
 }

--- a/Clock/Views/StatusView.swift
+++ b/Clock/Views/StatusView.swift
@@ -61,7 +61,7 @@ struct StatusView: View {
                     }
                 }
                 
-                if let apiVersion = status.api_version {
+                if let apiVersion = status.apiVersion {
                     Section(header: Text("Server Info")) {
                         HStack {
                             Text("API Version")


### PR DESCRIPTION
## Summary
- rename the status metadata properties to camelCase to match Swift conventions
- add coding keys so the new property names still decode snake_case payloads
- update StatusView to read the renamed API metadata property

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb981eea9c8330ac95d466423488b7