### PR TITLE
Fix WebSocket message decoding for status updates

### DIFF
--- a/Clock/Models/WSMessage.swift
+++ b/Clock/Models/WSMessage.swift
@@ -2,5 +2,38 @@ import Foundation
 
 struct WSMessage: Codable {
     let type: String
-    let status: ClockStatus?
+    let data: ClockStatus?
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case data
+        case status
+        case payload
+    }
+
+    init(type: String, data: ClockStatus?) {
+        self.type = type
+        self.data = data
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        type = try container.decode(String.self, forKey: .type)
+
+        if let decodedData = try container.decodeIfPresent(ClockStatus.self, forKey: .data) {
+            data = decodedData
+        } else if let decodedPayload = try container.decodeIfPresent(ClockStatus.self, forKey: .payload) {
+            data = decodedPayload
+        } else if let decodedStatus = try container.decodeIfPresent(ClockStatus.self, forKey: .status) {
+            data = decodedStatus
+        } else {
+            data = nil
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encodeIfPresent(data, forKey: .data)
+    }
 }

--- a/Clock/Networking/ClockWebSocket.swift
+++ b/Clock/Networking/ClockWebSocket.swift
@@ -60,7 +60,7 @@ final class ClockWebSocket: NSObject, ObservableObject, URLSessionWebSocketDeleg
                         decoder.keyDecodingStrategy = .convertFromSnakeCase
                         if let wsMessage = try? decoder.decode(WSMessage.self, from: data),
                            wsMessage.type == "status" {
-                            self?.status = wsMessage.status
+                            self?.status = wsMessage.data
                         }
                     }
                 case .data:


### PR DESCRIPTION
## Summary
- update `WSMessage` to decode the server's `data` payload while remaining compatible with older keys
- adjust `ClockWebSocket` to assign the decoded payload to its published status

## Testing
- not run (requires iOS environment)


------
https://chatgpt.com/codex/tasks/task_e_68cb9adb6ca48330a8a6f9ec430bc8f2