### PR TITLE
Decode status envelope

### DIFF
--- a/Clock/Networking/ClockAPI.swift
+++ b/Clock/Networking/ClockAPI.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+struct StatusEnvelope: Decodable {
+    let status: ClockStatus
+}
+
 // Struct for between rounds configuration
 struct BetweenRoundsConfig: Codable {
     let enabled: Bool
@@ -39,7 +43,7 @@ final class ClockAPI {
         let (data, _) = try await URLSession.shared.data(from: url)
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return try decoder.decode(ClockStatus.self, from: data)
+        return try decoder.decode(StatusEnvelope.self, from: data).status
     }
 }
 


### PR DESCRIPTION
## Summary
- introduce a StatusEnvelope type for decoding API responses
- update fetchStatus() to decode via StatusEnvelope and return the nested status

## Testing
- not run (requires iOS simulator to run the app against the server)

------
https://chatgpt.com/codex/tasks/task_e_68cb9adaa91c833081486a3207310157