### PR TITLE
Handle missing fields in status responses

### DIFF
--- a/Clock/Models/ClockStatus.swift
+++ b/Clock/Models/ClockStatus.swift
@@ -1,24 +1,24 @@
 import Foundation
 
 struct ClockStatus: Codable {
-    var minutes: Int
-    var seconds: Int
-    var currentRound: Int
-    var totalRounds: Int
-    var isRunning: Bool
-    var isPaused: Bool
-    var elapsedMinutes: Int
-    var elapsedSeconds: Int
-    var isBetweenRounds: Bool
-    var betweenRoundsMinutes: Int
-    var betweenRoundsSeconds: Int
-    var betweenRoundsEnabled: Bool
-    var betweenRoundsTime: Int
-    var warningLeadTime: Int
+    var minutes: Int = 0
+    var seconds: Int = 0
+    var currentRound: Int = 0
+    var totalRounds: Int = 0
+    var isRunning: Bool = false
+    var isPaused: Bool = false
+    var elapsedMinutes: Int = 0
+    var elapsedSeconds: Int = 0
+    var isBetweenRounds: Bool = false
+    var betweenRoundsMinutes: Int = 0
+    var betweenRoundsSeconds: Int = 0
+    var betweenRoundsEnabled: Bool = false
+    var betweenRoundsTime: Int = 0
+    var warningLeadTime: Int = 0
     var warningSoundPath: String?
     var endSoundPath: String?
-    var ntpSyncEnabled: Bool
-    var ntpOffset: Int
+    var ntpSyncEnabled: Bool = false
+    var ntpOffset: Int = 0
     var endTime: String?
     var timeStamp: String?
     // Extras returned by /status
@@ -50,5 +50,35 @@ struct ClockStatus: Codable {
         case serverTime
         case apiVersion = "api_version"
         case connectionProtocol = "connection_protocol"
+    }
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        minutes = try container.decodeIfPresent(Int.self, forKey: .minutes) ?? 0
+        seconds = try container.decodeIfPresent(Int.self, forKey: .seconds) ?? 0
+        currentRound = try container.decodeIfPresent(Int.self, forKey: .currentRound) ?? 0
+        totalRounds = try container.decodeIfPresent(Int.self, forKey: .totalRounds) ?? 0
+        isRunning = try container.decodeIfPresent(Bool.self, forKey: .isRunning) ?? false
+        isPaused = try container.decodeIfPresent(Bool.self, forKey: .isPaused) ?? false
+        elapsedMinutes = try container.decodeIfPresent(Int.self, forKey: .elapsedMinutes) ?? 0
+        elapsedSeconds = try container.decodeIfPresent(Int.self, forKey: .elapsedSeconds) ?? 0
+        isBetweenRounds = try container.decodeIfPresent(Bool.self, forKey: .isBetweenRounds) ?? false
+        betweenRoundsMinutes = try container.decodeIfPresent(Int.self, forKey: .betweenRoundsMinutes) ?? 0
+        betweenRoundsSeconds = try container.decodeIfPresent(Int.self, forKey: .betweenRoundsSeconds) ?? 0
+        betweenRoundsEnabled = try container.decodeIfPresent(Bool.self, forKey: .betweenRoundsEnabled) ?? false
+        betweenRoundsTime = try container.decodeIfPresent(Int.self, forKey: .betweenRoundsTime) ?? 0
+        warningLeadTime = try container.decodeIfPresent(Int.self, forKey: .warningLeadTime) ?? 0
+        warningSoundPath = try container.decodeIfPresent(String.self, forKey: .warningSoundPath)
+        endSoundPath = try container.decodeIfPresent(String.self, forKey: .endSoundPath)
+        ntpSyncEnabled = try container.decodeIfPresent(Bool.self, forKey: .ntpSyncEnabled) ?? false
+        ntpOffset = try container.decodeIfPresent(Int.self, forKey: .ntpOffset) ?? 0
+        endTime = try container.decodeIfPresent(String.self, forKey: .endTime)
+        timeStamp = try container.decodeIfPresent(String.self, forKey: .timeStamp)
+        serverTime = try container.decodeIfPresent(Int.self, forKey: .serverTime)
+        apiVersion = try container.decodeIfPresent(String.self, forKey: .apiVersion)
+        connectionProtocol = try container.decodeIfPresent(String.self, forKey: .connectionProtocol)
     }
 }

--- a/Clock/Networking/ClockAPI.swift
+++ b/Clock/Networking/ClockAPI.swift
@@ -43,7 +43,16 @@ final class ClockAPI {
         let (data, _) = try await URLSession.shared.data(from: url)
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return try decoder.decode(StatusEnvelope.self, from: data).status
+
+        if let envelope = try? decoder.decode(StatusEnvelope.self, from: data) {
+            return envelope.status
+        }
+
+        if let status = try? decoder.decode(ClockStatus.self, from: data) {
+            return status
+        }
+
+        throw URLError(.cannotDecodeContentData)
     }
 }
 


### PR DESCRIPTION
## Summary
- make `ClockStatus` decoding tolerant of missing fields so partial payloads from the server no longer fail to decode
- allow the REST status fetch to fall back to decoding a bare `ClockStatus` object when the response is not wrapped in a `status` envelope

## Testing
- not run (iOS project – no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb9c3224148330adc420541bf64703