### PR TITLE
Harden status decoding

### DIFF
--- a/Clock/Models/ClockStatus.swift
+++ b/Clock/Models/ClockStatus.swift
@@ -1,24 +1,24 @@
 import Foundation
 
 struct ClockStatus: Codable {
-    var minutes: Int
-    var seconds: Int
-    var currentRound: Int
-    var totalRounds: Int
-    var isRunning: Bool
-    var isPaused: Bool
-    var elapsedMinutes: Int
-    var elapsedSeconds: Int
-    var isBetweenRounds: Bool
-    var betweenRoundsMinutes: Int
-    var betweenRoundsSeconds: Int
-    var betweenRoundsEnabled: Bool
-    var betweenRoundsTime: Int
-    var warningLeadTime: Int
+    var minutes: Int = 0
+    var seconds: Int = 0
+    var currentRound: Int = 0
+    var totalRounds: Int = 0
+    var isRunning: Bool = false
+    var isPaused: Bool = false
+    var elapsedMinutes: Int = 0
+    var elapsedSeconds: Int = 0
+    var isBetweenRounds: Bool = false
+    var betweenRoundsMinutes: Int = 0
+    var betweenRoundsSeconds: Int = 0
+    var betweenRoundsEnabled: Bool = false
+    var betweenRoundsTime: Int = 0
+    var warningLeadTime: Int = 0
     var warningSoundPath: String?
     var endSoundPath: String?
-    var ntpSyncEnabled: Bool
-    var ntpOffset: Int
+    var ntpSyncEnabled: Bool = false
+    var ntpOffset: Int = 0
     var endTime: String?
     var timeStamp: String?
     // Extras returned by /status
@@ -50,5 +50,35 @@ struct ClockStatus: Codable {
         case serverTime
         case apiVersion = "api_version"
         case connectionProtocol = "connection_protocol"
+    }
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        minutes = try container.decodeIfPresent(Int.self, forKey: .minutes) ?? 0
+        seconds = try container.decodeIfPresent(Int.self, forKey: .seconds) ?? 0
+        currentRound = try container.decodeIfPresent(Int.self, forKey: .currentRound) ?? 0
+        totalRounds = try container.decodeIfPresent(Int.self, forKey: .totalRounds) ?? 0
+        isRunning = try container.decodeIfPresent(Bool.self, forKey: .isRunning) ?? false
+        isPaused = try container.decodeIfPresent(Bool.self, forKey: .isPaused) ?? false
+        elapsedMinutes = try container.decodeIfPresent(Int.self, forKey: .elapsedMinutes) ?? 0
+        elapsedSeconds = try container.decodeIfPresent(Int.self, forKey: .elapsedSeconds) ?? 0
+        isBetweenRounds = try container.decodeIfPresent(Bool.self, forKey: .isBetweenRounds) ?? false
+        betweenRoundsMinutes = try container.decodeIfPresent(Int.self, forKey: .betweenRoundsMinutes) ?? 0
+        betweenRoundsSeconds = try container.decodeIfPresent(Int.self, forKey: .betweenRoundsSeconds) ?? 0
+        betweenRoundsEnabled = try container.decodeIfPresent(Bool.self, forKey: .betweenRoundsEnabled) ?? false
+        betweenRoundsTime = try container.decodeIfPresent(Int.self, forKey: .betweenRoundsTime) ?? 0
+        warningLeadTime = try container.decodeIfPresent(Int.self, forKey: .warningLeadTime) ?? 0
+        warningSoundPath = try container.decodeIfPresent(String.self, forKey: .warningSoundPath)
+        endSoundPath = try container.decodeIfPresent(String.self, forKey: .endSoundPath)
+        ntpSyncEnabled = try container.decodeIfPresent(Bool.self, forKey: .ntpSyncEnabled) ?? false
+        ntpOffset = try container.decodeIfPresent(Int.self, forKey: .ntpOffset) ?? 0
+        endTime = try container.decodeIfPresent(String.self, forKey: .endTime)
+        timeStamp = try container.decodeIfPresent(String.self, forKey: .timeStamp)
+        serverTime = try container.decodeIfPresent(Int.self, forKey: .serverTime)
+        apiVersion = try container.decodeIfPresent(String.self, forKey: .apiVersion)
+        connectionProtocol = try container.decodeIfPresent(String.self, forKey: .connectionProtocol)
     }
 }

--- a/Clock/Models/WSMessage.swift
+++ b/Clock/Models/WSMessage.swift
@@ -6,6 +6,7 @@ struct WSMessage: Codable {
 
     private enum CodingKeys: String, CodingKey {
         case type
+        case event
         case data
         case status
         case payload
@@ -18,7 +19,16 @@ struct WSMessage: Codable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        type = try container.decode(String.self, forKey: .type)
+
+        if let decodedType = try container.decodeIfPresent(String.self, forKey: .type) {
+            type = decodedType
+        } else if let decodedEvent = try container.decodeIfPresent(String.self, forKey: .event) {
+            type = decodedEvent
+        } else if container.contains(.data) || container.contains(.payload) || container.contains(.status) {
+            type = "status"
+        } else {
+            type = ""
+        }
 
         if let decodedData = try container.decodeIfPresent(ClockStatus.self, forKey: .data) {
             data = decodedData

--- a/Clock/Networking/ClockAPI.swift
+++ b/Clock/Networking/ClockAPI.swift
@@ -4,6 +4,14 @@ struct StatusEnvelope: Decodable {
     let status: ClockStatus
 }
 
+enum ClockAPIError: LocalizedError {
+    case unexpectedStatusPayload
+
+    var errorDescription: String? {
+        "The server returned the status in an unexpected format."
+    }
+}
+
 // Struct for between rounds configuration
 struct BetweenRoundsConfig: Codable {
     let enabled: Bool
@@ -22,6 +30,32 @@ struct RoundsConfig: Codable {
 }
 
 final class ClockAPI {
+    private static let statusFieldKeys: Set<String> = [
+        "minutes",
+        "seconds",
+        "currentround",
+        "totalrounds",
+        "isrunning",
+        "ispaused",
+        "elapsedminutes",
+        "elapsedseconds",
+        "isbetweenrounds",
+        "betweenroundsminutes",
+        "betweenroundsseconds",
+        "betweenroundsenabled",
+        "betweenroundstime",
+        "warningleadtime",
+        "warningsoundpath",
+        "endsoundpath",
+        "ntpsyncenabled",
+        "ntpoffset",
+        "endtime",
+        "timestamp",
+        "servertime",
+        "apiversion",
+        "connectionprotocol",
+    ]
+
     var baseURL: URL
 
     init(host: String, port: Int = 4040) {
@@ -41,9 +75,72 @@ final class ClockAPI {
     func fetchStatus() async throws -> ClockStatus {
         let url = baseURL.appendingPathComponent("status")
         let (data, _) = try await URLSession.shared.data(from: url)
+
+        if let status = decodeStatusPayload(from: data) {
+            return status
+        }
+
+        throw ClockAPIError.unexpectedStatusPayload
+    }
+
+    private func decodeStatusPayload(from data: Data) -> ClockStatus? {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return try decoder.decode(StatusEnvelope.self, from: data).status
+
+        if let envelope = try? decoder.decode(StatusEnvelope.self, from: data) {
+            return envelope.status
+        }
+
+        if let message = try? decoder.decode(WSMessage.self, from: data),
+           let status = message.data {
+            return status
+        }
+
+        if let status = try? decoder.decode(ClockStatus.self, from: data) {
+            return status
+        }
+
+        guard let jsonObject = try? JSONSerialization.jsonObject(with: data) else {
+            return nil
+        }
+
+        return extractStatus(from: jsonObject, using: decoder)
+    }
+
+    private func extractStatus(from object: Any, using decoder: JSONDecoder) -> ClockStatus? {
+        if let dictionary = object as? [String: Any] {
+            if dictionaryContainsStatusData(dictionary),
+               JSONSerialization.isValidJSONObject(dictionary),
+               let data = try? JSONSerialization.data(withJSONObject: dictionary),
+               let status = try? decoder.decode(ClockStatus.self, from: data) {
+                return status
+            }
+
+            for value in dictionary.values {
+                if let status = extractStatus(from: value, using: decoder) {
+                    return status
+                }
+            }
+        } else if let array = object as? [Any] {
+            for element in array {
+                if let status = extractStatus(from: element, using: decoder) {
+                    return status
+                }
+            }
+        }
+
+        return nil
+    }
+
+    private func dictionaryContainsStatusData(_ dictionary: [String: Any]) -> Bool {
+        for key in dictionary.keys {
+            let normalizedKey = key.replacingOccurrences(of: "_", with: "").lowercased()
+            if Self.statusFieldKeys.contains(normalizedKey) {
+                return true
+            }
+        }
+
+        return false
     }
 }
 


### PR DESCRIPTION
## Summary
- add a descriptive `ClockAPIError` and broaden the status parser to understand envelopes, WebSocket-shaped messages, and nested payloads before failing
- teach `WSMessage` to treat `event` as an alias for `type` and default to a status message when a payload is present

## Testing
- not run (iOS project – no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68cb9c3224148330adc420541bf64703