### PR TITLE
Refine status detection when decoding clock updates

### DIFF
--- a/Clock/Models/ClockStatus.swift
+++ b/Clock/Models/ClockStatus.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct ClockStatus: Codable {
+struct ClockStatus: Codable, Equatable {
     var minutes: Int = 0
     var seconds: Int = 0
     var currentRound: Int = 0
@@ -80,5 +80,12 @@ struct ClockStatus: Codable {
         serverTime = try container.decodeIfPresent(Int.self, forKey: .serverTime)
         apiVersion = try container.decodeIfPresent(String.self, forKey: .apiVersion)
         connectionProtocol = try container.decodeIfPresent(String.self, forKey: .connectionProtocol)
+    }
+}
+
+extension ClockStatus {
+    /// Returns `true` when at least one property differs from the default `ClockStatus` value.
+    var hasAnyStatusFields: Bool {
+        self != ClockStatus()
     }
 }

--- a/Clock/Models/WSMessage.swift
+++ b/Clock/Models/WSMessage.swift
@@ -30,11 +30,19 @@ struct WSMessage: Codable {
             type = ""
         }
 
-        if let decodedData = try container.decodeIfPresent(ClockStatus.self, forKey: .data) {
+        func decodeStatus(for key: CodingKeys) -> ClockStatus? {
+            guard let status = try? container.decodeIfPresent(ClockStatus.self, forKey: key),
+                  status.hasAnyStatusFields else {
+                return nil
+            }
+            return status
+        }
+
+        if let decodedData = decodeStatus(for: .data) {
             data = decodedData
-        } else if let decodedPayload = try container.decodeIfPresent(ClockStatus.self, forKey: .payload) {
+        } else if let decodedPayload = decodeStatus(for: .payload) {
             data = decodedPayload
-        } else if let decodedStatus = try container.decodeIfPresent(ClockStatus.self, forKey: .status) {
+        } else if let decodedStatus = decodeStatus(for: .status) {
             data = decodedStatus
         } else {
             data = nil

--- a/Clock/Networking/ClockAPI.swift
+++ b/Clock/Networking/ClockAPI.swift
@@ -87,19 +87,22 @@ final class ClockAPI {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
 
-        if let envelope = try? decoder.decode(StatusEnvelope.self, from: data) {
+        if let envelope = try? decoder.decode(StatusEnvelope.self, from: data),
+           envelope.status.hasAnyStatusFields {
             return envelope.status
         }
 
 
         if let message = try? decoder.decode(WSMessage.self, from: data),
-           let status = message.data {
+           let status = message.data,
+           status.hasAnyStatusFields {
             return status
         }
 
 
 
-        if let status = try? decoder.decode(ClockStatus.self, from: data) {
+        if let status = try? decoder.decode(ClockStatus.self, from: data),
+           status.hasAnyStatusFields {
             return status
         }
 
@@ -116,7 +119,8 @@ final class ClockAPI {
             if dictionaryContainsStatusData(dictionary),
                JSONSerialization.isValidJSONObject(dictionary),
                let data = try? JSONSerialization.data(withJSONObject: dictionary),
-               let status = try? decoder.decode(ClockStatus.self, from: data) {
+               let status = try? decoder.decode(ClockStatus.self, from: data),
+               status.hasAnyStatusFields {
                 return status
             }
 


### PR DESCRIPTION
## Summary
- have `ClockStatus` leverage synthesized `Equatable` conformance so `hasAnyStatusFields` simply compares against the default instance
- require nested dictionary decodes to return a status only when meaningful fields were actually populated

## Testing
- `swiftc Clock/Models/ClockStatus.swift Clock/Models/WSMessage.swift /tmp/main.swift -o /tmp/test && /tmp/test`


------
https://chatgpt.com/codex/tasks/task_e_68cba25b43d48330958c4790f0d531b3