### PR TITLE
Handle zero-valued status payloads with explicit keys

### DIFF
--- a/Clock/Models/ClockStatus.swift
+++ b/Clock/Models/ClockStatus.swift
@@ -26,6 +26,8 @@ struct ClockStatus: Codable, Equatable {
     var apiVersion: String?
     var connectionProtocol: String?
 
+    private var hasDecodedStatusKeys: Bool?
+
     enum CodingKeys: String, CodingKey {
         case minutes
         case seconds
@@ -57,6 +59,8 @@ struct ClockStatus: Codable, Equatable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
+        hasDecodedStatusKeys = !container.allKeys.isEmpty
+
         minutes = try container.decodeIfPresent(Int.self, forKey: .minutes) ?? 0
         seconds = try container.decodeIfPresent(Int.self, forKey: .seconds) ?? 0
         currentRound = try container.decodeIfPresent(Int.self, forKey: .currentRound) ?? 0
@@ -86,8 +90,38 @@ struct ClockStatus: Codable, Equatable {
 extension ClockStatus {
     /// Returns `true` when at least one property differs from the default `ClockStatus` value.
     var hasAnyStatusFields: Bool {
+        if let hasDecodedStatusKeys {
+            return hasDecodedStatusKeys
+        }
 
-        self != ClockStatus()
+        return self != ClockStatus()
+    }
+}
 
+extension ClockStatus {
+    static func == (lhs: ClockStatus, rhs: ClockStatus) -> Bool {
+        lhs.minutes == rhs.minutes &&
+        lhs.seconds == rhs.seconds &&
+        lhs.currentRound == rhs.currentRound &&
+        lhs.totalRounds == rhs.totalRounds &&
+        lhs.isRunning == rhs.isRunning &&
+        lhs.isPaused == rhs.isPaused &&
+        lhs.elapsedMinutes == rhs.elapsedMinutes &&
+        lhs.elapsedSeconds == rhs.elapsedSeconds &&
+        lhs.isBetweenRounds == rhs.isBetweenRounds &&
+        lhs.betweenRoundsMinutes == rhs.betweenRoundsMinutes &&
+        lhs.betweenRoundsSeconds == rhs.betweenRoundsSeconds &&
+        lhs.betweenRoundsEnabled == rhs.betweenRoundsEnabled &&
+        lhs.betweenRoundsTime == rhs.betweenRoundsTime &&
+        lhs.warningLeadTime == rhs.warningLeadTime &&
+        lhs.warningSoundPath == rhs.warningSoundPath &&
+        lhs.endSoundPath == rhs.endSoundPath &&
+        lhs.ntpSyncEnabled == rhs.ntpSyncEnabled &&
+        lhs.ntpOffset == rhs.ntpOffset &&
+        lhs.endTime == rhs.endTime &&
+        lhs.timeStamp == rhs.timeStamp &&
+        lhs.serverTime == rhs.serverTime &&
+        lhs.apiVersion == rhs.apiVersion &&
+        lhs.connectionProtocol == rhs.connectionProtocol
     }
 }

--- a/Clock/Networking/ClockAPI.swift
+++ b/Clock/Networking/ClockAPI.swift
@@ -83,7 +83,7 @@ final class ClockAPI {
         throw ClockAPIError.unexpectedStatusPayload
     }
 
-    private func decodeStatusPayload(from data: Data) -> ClockStatus? {
+    func decodeStatusPayload(from data: Data) -> ClockStatus? {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
 

--- a/ClockTests/StatusDecodingTests.swift
+++ b/ClockTests/StatusDecodingTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Clock
+
+final class StatusDecodingTests: XCTestCase {
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
+
+    func testDecodeZeroStatusFromRESTPayload() throws {
+        let payload = Data(#"{"status":{"minutes":0,"seconds":0}}"#.utf8)
+        let api = ClockAPI(host: "example.com")
+
+        let status = api.decodeStatusPayload(from: payload)
+
+        XCTAssertNotNil(status)
+        XCTAssertEqual(status?.minutes, 0)
+        XCTAssertEqual(status?.seconds, 0)
+    }
+
+    func testDecodeZeroStatusFromWebSocketPayload() throws {
+        let payload = Data(#"{"type":"status","data":{"minutes":0,"seconds":0}}"#.utf8)
+
+        let message = try decoder.decode(WSMessage.self, from: payload)
+
+        XCTAssertNotNil(message.data)
+        XCTAssertEqual(message.data?.minutes, 0)
+        XCTAssertEqual(message.data?.seconds, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- record when `ClockStatus` decoders encounter keys so zero-valued but explicitly keyed payloads register as real status objects
- continue filtering status payloads via `hasAnyStatusFields`, exposing the decoder helper for reuse in regression coverage
- add regression tests that decode a `{"status":{"minutes":0,"seconds":0}}` payload through both the REST and WebSocket paths

## Testing
- not run (xcodebuild is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cbac6632148330a6bfea24a7ff0ce8