### PR TITLE
Merge websocket status updates

### DIFF
--- a/Clock/Networking/ClockWebSocket.swift
+++ b/Clock/Networking/ClockWebSocket.swift
@@ -60,7 +60,15 @@ final class ClockWebSocket: NSObject, ObservableObject, URLSessionWebSocketDeleg
                         decoder.keyDecodingStrategy = .convertFromSnakeCase
                         if let wsMessage = try? decoder.decode(WSMessage.self, from: data),
                            wsMessage.type == "status" {
-                            self?.status = wsMessage.data
+                            if let patch = wsMessage.data {
+                                if let currentStatus = self?.status {
+                                    self?.status = currentStatus.merging(patch)
+                                } else {
+                                    self?.status = patch
+                                }
+                            } else {
+                                self?.status = nil
+                            }
                         }
                     }
                 case .data:

--- a/ClockTests/StatusDecodingTests.swift
+++ b/ClockTests/StatusDecodingTests.swift
@@ -28,4 +28,22 @@ final class StatusDecodingTests: XCTestCase {
         XCTAssertEqual(message.data?.minutes, 0)
         XCTAssertEqual(message.data?.seconds, 0)
     }
+
+    func testWebSocketPayloadMergesIntoExistingStatus() throws {
+        var existingStatus = ClockStatus()
+        existingStatus.minutes = 2
+        existingStatus.seconds = 10
+        existingStatus.currentRound = 3
+
+        let payload = Data(#"{"type":"status","data":{"seconds":45}}"#.utf8)
+
+        let message = try decoder.decode(WSMessage.self, from: payload)
+        let patch = try XCTUnwrap(message.data)
+
+        let mergedStatus = existingStatus.merging(patch)
+
+        XCTAssertEqual(mergedStatus.minutes, 2)
+        XCTAssertEqual(mergedStatus.seconds, 45)
+        XCTAssertEqual(mergedStatus.currentRound, 3)
+    }
 }


### PR DESCRIPTION
## Summary
- record which fields were decoded on ClockStatus instances and add a helper to merge patches
- merge incoming WebSocket status updates into the last known status instead of replacing it
- add a unit test that ensures partial WebSocket payloads preserve previously known values

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68cc21420d9483308cd0c1be272719b7