### PR TITLE
Prevent websocket patches from resetting the timer

### DIFF
--- a/Clock/ViewModels/ClockViewModel.swift
+++ b/Clock/ViewModels/ClockViewModel.swift
@@ -40,11 +40,9 @@ final class ClockViewModel: ObservableObject {
                 self?.isConnected = connected
             }
         }
-        newWebSocket.onStatusUpdate = { [weak self] newStatus in
+        newWebSocket.onStatusUpdate = { [weak self] patch in
             DispatchQueue.main.async {
-                if self?.status != newStatus {
-                    self?.status = newStatus
-                }
+                self?.applyStatusPatch(patch)
             }
         }
         self.webSocket = newWebSocket
@@ -95,7 +93,18 @@ final class ClockViewModel: ObservableObject {
             self.status = newStatus
         }
     }
-    
+
+    func applyStatusPatch(_ patch: ClockStatus) {
+        if let existingStatus = status {
+            let mergedStatus = existingStatus.merging(patch)
+            if mergedStatus != existingStatus {
+                status = mergedStatus
+            }
+        } else {
+            status = patch
+        }
+    }
+
     // MARK: - API Actions
     
     func start() async throws { try await api?.start() }

--- a/ClockTests/StatusDecodingTests.swift
+++ b/ClockTests/StatusDecodingTests.swift
@@ -46,4 +46,26 @@ final class StatusDecodingTests: XCTestCase {
         XCTAssertEqual(mergedStatus.seconds, 45)
         XCTAssertEqual(mergedStatus.currentRound, 3)
     }
+
+    @MainActor
+    func testActionAcknowledgementDoesNotResetTimer() throws {
+        let viewModel = ClockViewModel()
+
+        var initialStatus = ClockStatus()
+        initialStatus.minutes = 3
+        initialStatus.seconds = 15
+        initialStatus.isRunning = true
+
+        viewModel.status = initialStatus
+
+        let payload = Data(#"{"type":"ack","status":{"isRunning":false}}"#.utf8)
+        let message = try decoder.decode(WSMessage.self, from: payload)
+        let patch = try XCTUnwrap(message.data)
+
+        viewModel.applyStatusPatch(patch)
+
+        XCTAssertEqual(viewModel.status?.minutes, 3)
+        XCTAssertEqual(viewModel.status?.seconds, 15)
+        XCTAssertEqual(viewModel.status?.isRunning, false)
+    }
 }


### PR DESCRIPTION
## Summary
- merge incoming websocket status patches into the existing status and only publish when the merged value changes
- expose the merge logic via `applyStatusPatch(_:)` so it can be exercised directly
- add a regression test that ensures acknowledgements without timer fields no longer reset the published timer

## Testing
- not run (xcodebuild is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd02c98d8c8330822af69249fb533d