### PR TITLE
Switch digital timer to UFCSans font

### DIFF
--- a/Clock.xcodeproj/project.pbxproj
+++ b/Clock.xcodeproj/project.pbxproj
@@ -253,8 +253,11 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = QQJQB3A4LJ;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                INFOPLIST_KEY_UIAppFonts = (
+                                        "UFCSans-Bold.ttf",
+                                );
+                                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -281,8 +284,11 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = QQJQB3A4LJ;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                INFOPLIST_KEY_UIAppFonts = (
+                                        "UFCSans-Bold.ttf",
+                                );
+                                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/Clock/Views/DigitalFont.swift
+++ b/Clock/Views/DigitalFont.swift
@@ -5,7 +5,7 @@ struct DigitalFont: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .font(.custom("DS-Digital", size: size))
+            .font(.custom("UFCSans-Bold", size: size))
             .monospacedDigit()
     }
 }


### PR DESCRIPTION
## Summary
- update the digital font modifier to use the UFCSans-Bold custom font
- register the UFCSans-Bold font in the target Info settings so it is bundled and available at runtime

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68cd5d937178833090974cd0724e4e84