### PR TITLE
Adjust round info layout and typography

### DIFF
--- a/Clock/Views/ControlView.swift
+++ b/Clock/Views/ControlView.swift
@@ -36,15 +36,16 @@ struct ControlView: View {
                                 }
                             }
                         }
-                    
+
+                    roundInfoView()
+                        .padding(.top, 12)
+
                     Spacer()
-                    
-                    HStack {
-                        connectionInfoView()
-                        Spacer()
-                        roundInfoView()
-                    }
-                    .padding(.horizontal, 30)
+
+                    connectionInfoView()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 30)
+                        .padding(.bottom, 12)
 
                     controlButtons()
                         .padding(.bottom, 30)
@@ -124,7 +125,7 @@ struct ControlView: View {
                 Text("ROUND 0 of 0")
             }
         }
-        .digitalFont(size: 24)
+        .digitalFont(size: 32)
         .foregroundColor(.white)
     }
     


### PR DESCRIPTION
## Summary
- move the round information display directly beneath the status bar in the control view hierarchy
- enlarge the round information font for improved readability
- realign the connection info layout after moving the round details

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd5d9427dc83309f0b57e2fccfb413