### PR TITLE
Add navigation menu and digital font view

### DIFF
--- a/Clock/Views/DigitalFontView.swift
+++ b/Clock/Views/DigitalFontView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+struct DigitalFontView: View {
+    private let samples: [Sample] = [
+        Sample(title: "Timer", value: "12:34", size: 100, color: .green),
+        Sample(title: "Rounds", value: "RND 05", size: 60, color: .yellow),
+        Sample(title: "Status", value: "PAUSED", size: 48, color: .orange),
+        Sample(title: "Elapsed", value: "00:59", size: 72, color: .red)
+    ]
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                Text("Digital Font Showcase")
+                    .font(.title.bold())
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text("The DS-Digital typeface keeps the timer easy to read from a distance. These examples demonstrate how the custom digitalFont(size:) modifier can be applied with different colors and sizes.")
+                    .font(.body)
+                    .foregroundColor(.white.opacity(0.7))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                ForEach(samples) { sample in
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(sample.title.uppercased())
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.6))
+
+                        Text(sample.value)
+                            .digitalFont(size: sample.size)
+                            .foregroundColor(sample.color)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 16)
+                            .background(Color.white.opacity(0.1))
+                            .cornerRadius(12)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Usage")
+                        .font(.headline)
+                        .foregroundColor(.white)
+
+                    Text("Apply the modifier to any text element to match the primary clock interface.")
+                        .foregroundColor(.white.opacity(0.7))
+
+                    Text("Text(\"12:34\")\n    .digitalFont(size: 80)\n    .foregroundColor(.green)")
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.9))
+                        .padding()
+                        .background(Color.white.opacity(0.1))
+                        .cornerRadius(12)
+                }
+
+                Spacer(minLength: 12)
+            }
+            .padding(24)
+        }
+        .background(Color.black.edgesIgnoringSafeArea(.all))
+        .navigationTitle("Digital Font")
+    }
+}
+
+private struct Sample: Identifiable {
+    let id = UUID()
+    let title: String
+    let value: String
+    let size: CGFloat
+    let color: Color
+}

--- a/Clock/Views/MainTabView.swift
+++ b/Clock/Views/MainTabView.swift
@@ -2,21 +2,90 @@ import SwiftUI
 
 struct MainTabView: View {
     @EnvironmentObject var clockViewModel: ClockViewModel
+    @State private var navigationPath = NavigationPath()
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $navigationPath) {
             ControlView()
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
-                        NavigationLink {
-                            SettingsView()
-                                .environmentObject(clockViewModel)
+                        Menu {
+                            ForEach(MainDestination.navigationOptions, id: \.self) { destination in
+                                Button(destination.title) {
+                                    navigate(to: destination)
+                                }
+                                .accessibilityIdentifier(destination.accessibilityIdentifier)
+                            }
                         } label: {
-                            Image(systemName: "gearshape")
+                            Image(systemName: "ellipsis.circle")
                                 .imageScale(.large)
                         }
                     }
                 }
+                .navigationTitle("Control")
+                .navigationDestination(for: MainDestination.self) { destination in
+                    destinationView(for: destination)
+                }
         }
+    }
+
+    private func navigate(to destination: MainDestination) {
+        if destination == .control {
+            navigationPath = NavigationPath()
+        } else {
+            navigationPath = NavigationPath()
+            navigationPath.append(destination)
+        }
+    }
+
+    @ViewBuilder
+    private func destinationView(for destination: MainDestination) -> some View {
+        switch destination {
+        case .connection:
+            ConnectionView()
+                .environmentObject(clockViewModel)
+        case .control:
+            ControlView()
+                .environmentObject(clockViewModel)
+        case .settings:
+            SettingsView()
+                .environmentObject(clockViewModel)
+        case .status:
+            StatusView()
+                .environmentObject(clockViewModel)
+        case .digitalFont:
+            DigitalFontView()
+        }
+    }
+}
+
+private enum MainDestination: String, CaseIterable, Hashable {
+    case connection
+    case control
+    case settings
+    case status
+    case digitalFont
+
+    static var navigationOptions: [MainDestination] {
+        [.connection, .control, .settings, .status, .digitalFont]
+    }
+
+    var title: String {
+        switch self {
+        case .connection:
+            return "Connection"
+        case .control:
+            return "Control"
+        case .settings:
+            return "Settings"
+        case .status:
+            return "Status"
+        case .digitalFont:
+            return "Digital Font"
+        }
+    }
+
+    var accessibilityIdentifier: String {
+        "main_destination_\(rawValue)"
     }
 }


### PR DESCRIPTION
## Summary
- replace the MainTabView gear button with a menu that routes to the connection, control, settings, status, and digital font screens
- manage navigation with a NavigationPath so choosing an item pushes the appropriate destination
- add a digital font showcase view demonstrating how the custom modifier looks and how it can be applied

## Testing
- not run (iOS tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd5d9527348330bf46b8c96c8137ac