### PR TITLE
Make timer text bolder and enlarge round label

### DIFF
--- a/Clock/Views/ControlView.swift
+++ b/Clock/Views/ControlView.swift
@@ -79,7 +79,7 @@ struct ControlView: View {
             ?? "00:00"
 
         return Text(displayText)
-            .digitalFont(size: 150)
+            .digitalFont(size: 150, weight: .black)
             .foregroundColor(.white)
             .minimumScaleFactor(0.5)
             .lineLimit(1)
@@ -125,7 +125,7 @@ struct ControlView: View {
                 Text("ROUND 0 of 0")
             }
         }
-        .digitalFont(size: 32)
+        .digitalFont(size: 44)
         .foregroundColor(.white)
     }
     

--- a/Clock/Views/DigitalFont.swift
+++ b/Clock/Views/DigitalFont.swift
@@ -2,16 +2,25 @@ import SwiftUI
 
 struct DigitalFont: ViewModifier {
     var size: CGFloat
+    var weight: Font.Weight?
 
     func body(content: Content) -> some View {
         content
-            .font(.custom("UFCSans-Bold", size: size))
+            .font(resolvedFont)
             .monospacedDigit()
+    }
+
+    private var resolvedFont: Font {
+        if let weight {
+            return Font.custom("UFCSans-Bold", size: size).weight(weight)
+        }
+
+        return Font.custom("UFCSans-Bold", size: size)
     }
 }
 
 extension View {
-    func digitalFont(size: CGFloat) -> some View {
-        self.modifier(DigitalFont(size: size))
+    func digitalFont(size: CGFloat, weight: Font.Weight? = nil) -> some View {
+        self.modifier(DigitalFont(size: size, weight: weight))
     }
 }


### PR DESCRIPTION
## Summary
- allow the digital font modifier to accept an optional font weight override
- apply a heavier weight to the main timer display for a bolder clock appearance
- enlarge the round indicator text to improve readability

## Testing
- not run (iOS project; no automated tests executed)


------
https://chatgpt.com/codex/tasks/task_e_68cd60d5a6a48330b3987d1357872f34