### PR TITLE
Add between rounds status text

### DIFF
--- a/Clock/Views/ControlView.swift
+++ b/Clock/Views/ControlView.swift
@@ -164,7 +164,9 @@ struct ControlView: View {
     }
     
     private func getStatusText() -> String {
-        guard let status = clockViewModel.status, status.isRunning else { return "READY" }
+        guard let status = clockViewModel.status else { return "READY" }
+        if status.isBetweenRounds { return "BETWEEN ROUNDS" }
+        guard status.isRunning else { return "READY" }
         return status.isPaused ? "PAUSED" : "RUNNING"
     }
 


### PR DESCRIPTION
## Summary
- ensure the control view displays "BETWEEN ROUNDS" when the status is between rounds
- preserve existing READY/PAUSED/RUNNING text for other states

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd657dc04c833089191e641afea556