### PR TITLE
Use purple status color between rounds

### DIFF
--- a/Clock/Views/ControlView.swift
+++ b/Clock/Views/ControlView.swift
@@ -175,6 +175,9 @@ struct ControlView: View {
 
     private func getStatusColor() -> Color {
         guard let status = clockViewModel.status, status.isRunning else { return .gray }
+        if status.isBetweenRounds {
+            return .purple
+        }
         return status.isPaused ? .yellow : .green
     }
 }


### PR DESCRIPTION
## Summary
- return a purple status color when the timer status is between rounds
- allow the status bar background and timer stroke to reflect the between-rounds state

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd657ec04c83308d10d746cf457805