### PR TITLE
Add dedicated time configuration screen

### DIFF
--- a/Clock/Views/ConnectionsView.swift
+++ b/Clock/Views/ConnectionsView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct ConnectionsView: View {
     @EnvironmentObject var clockViewModel: ClockViewModel
-    @StateObject private var settingsViewModel = SettingsViewModel()
 
     var body: some View {
         Form {
@@ -30,54 +29,8 @@ struct ConnectionsView: View {
                 .frame(maxWidth: .infinity)
             }
 
-            Section(header: Text("Timer Settings")) {
-                Stepper(
-                    "Minutes: \(settingsViewModel.minutes)",
-                    value: $settingsViewModel.minutes,
-                    in: 0...60
-                )
-
-                Stepper(
-                    "Seconds: \(settingsViewModel.seconds)",
-                    value: $settingsViewModel.seconds,
-                    in: 0...59
-                )
-            }
-
-            Section(header: Text("Round Settings")) {
-                Stepper(
-                    "Total Rounds: \(settingsViewModel.totalRounds)",
-                    value: $settingsViewModel.totalRounds,
-                    in: 1...99
-                )
-            }
-
-            Section(header: Text("Between Rounds")) {
-                Toggle("Enable Between Rounds", isOn: $settingsViewModel.betweenRoundsEnabled)
-
-                if settingsViewModel.betweenRoundsEnabled {
-                    Stepper(
-                        "Time: \(settingsViewModel.betweenRoundsTime)s",
-                        value: $settingsViewModel.betweenRoundsTime,
-                        in: 10...300
-                    )
-                }
-            }
-
-            Section {
-                Button("Apply Settings") {
-                    Task {
-                        try? await settingsViewModel.applySettings(clockViewModel: clockViewModel)
-                    }
-                }
-                .frame(maxWidth: .infinity)
-                .disabled(!clockViewModel.isConnected)
-            }
         }
         .navigationTitle("Connections")
         .navigationBarTitleDisplayMode(.large)
-        .onAppear {
-            settingsViewModel.loadSettings()
-        }
     }
 }

--- a/Clock/Views/MainTabView.swift
+++ b/Clock/Views/MainTabView.swift
@@ -44,6 +44,9 @@ struct MainTabView: View {
         case .connections:
             ConnectionsView()
                 .environmentObject(clockViewModel)
+        case .timeConfig:
+            TimeConfigView()
+                .environmentObject(clockViewModel)
         case .control:
             ControlView()
                 .environmentObject(clockViewModel)
@@ -58,18 +61,21 @@ struct MainTabView: View {
 
 private enum MainDestination: String, CaseIterable, Hashable {
     case connections
+    case timeConfig
     case control
     case status
     case digitalFont
 
     static var navigationOptions: [MainDestination] {
-        [.connections, .control, .status, .digitalFont]
+        [.connections, .timeConfig, .control, .status, .digitalFont]
     }
 
     var title: String {
         switch self {
         case .connections:
             return "Connections"
+        case .timeConfig:
+            return "Time Config"
         case .control:
             return "Control"
         case .status:

--- a/Clock/Views/TimeConfigView.swift
+++ b/Clock/Views/TimeConfigView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct TimeConfigView: View {
+    @EnvironmentObject var clockViewModel: ClockViewModel
+    @StateObject private var settingsViewModel = SettingsViewModel()
+
+    var body: some View {
+        Form {
+            Section(header: Text("Timer Settings")) {
+                Stepper(
+                    "Minutes: \(settingsViewModel.minutes)",
+                    value: $settingsViewModel.minutes,
+                    in: 0...60
+                )
+
+                Stepper(
+                    "Seconds: \(settingsViewModel.seconds)",
+                    value: $settingsViewModel.seconds,
+                    in: 0...59
+                )
+            }
+
+            Section(header: Text("Round Settings")) {
+                Stepper(
+                    "Total Rounds: \(settingsViewModel.totalRounds)",
+                    value: $settingsViewModel.totalRounds,
+                    in: 1...99
+                )
+            }
+
+            Section(header: Text("Between Rounds")) {
+                Toggle("Enable Between Rounds", isOn: $settingsViewModel.betweenRoundsEnabled)
+
+                if settingsViewModel.betweenRoundsEnabled {
+                    Stepper(
+                        "Time: \(settingsViewModel.betweenRoundsTime)s",
+                        value: $settingsViewModel.betweenRoundsTime,
+                        in: 10...300
+                    )
+                }
+            }
+
+            Section {
+                Button("Apply Settings") {
+                    Task {
+                        try? await settingsViewModel.applySettings(clockViewModel: clockViewModel)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .disabled(!clockViewModel.isConnected)
+            }
+        }
+        .navigationTitle("Time Config")
+        .navigationBarTitleDisplayMode(.large)
+        .onAppear {
+            settingsViewModel.loadSettings()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create a dedicated TimeConfigView for adjusting timer, round, and between-round settings with an apply action
- streamline ConnectionsView to focus on connection controls only
- expose the new Time Config screen through the main navigation menu

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce23d93e6c8330b8162dd748837121