### PR TITLE
Add combined settings destination

### DIFF
--- a/Clock/Views/MainTabView.swift
+++ b/Clock/Views/MainTabView.swift
@@ -41,14 +41,11 @@ struct MainTabView: View {
     @ViewBuilder
     private func destinationView(for destination: MainDestination) -> some View {
         switch destination {
-        case .connections:
-            ConnectionsView()
+        case .settings:
+            SettingsHubView()
                 .environmentObject(clockViewModel)
         case .control:
             ControlView()
-                .environmentObject(clockViewModel)
-        case .status:
-            StatusView()
                 .environmentObject(clockViewModel)
         case .digitalFont:
             DigitalFontView()
@@ -57,23 +54,20 @@ struct MainTabView: View {
 }
 
 private enum MainDestination: String, CaseIterable, Hashable {
-    case connections
+    case settings
     case control
-    case status
     case digitalFont
 
     static var navigationOptions: [MainDestination] {
-        [.connections, .control, .status, .digitalFont]
+        [.settings, .control, .digitalFont]
     }
 
     var title: String {
         switch self {
-        case .connections:
-            return "Connections"
+        case .settings:
+            return "Settings"
         case .control:
             return "Control"
-        case .status:
-            return "Status"
         case .digitalFont:
             return "Digital Font"
         }

--- a/Clock/Views/SettingsHubView.swift
+++ b/Clock/Views/SettingsHubView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct SettingsHubView: View {
+    @EnvironmentObject private var clockViewModel: ClockViewModel
+    @State private var selectedTab: SettingsTab = .connections
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Picker("Settings", selection: $selectedTab) {
+                ForEach(SettingsTab.allCases) { tab in
+                    Text(tab.title)
+                        .tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal)
+
+            Group {
+                switch selectedTab {
+                case .connections:
+                    ConnectionsView()
+                        .environmentObject(clockViewModel)
+                case .status:
+                    StatusView()
+                        .environmentObject(clockViewModel)
+                }
+            }
+        }
+        .navigationTitle(selectedTab.navigationTitle)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private enum SettingsTab: String, CaseIterable, Identifiable {
+    case connections
+    case status
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .connections:
+            return "Connections"
+        case .status:
+            return "Status"
+        }
+    }
+
+    var navigationTitle: String {
+        title
+    }
+}


### PR DESCRIPTION
## Summary
- add a SettingsHubView that lets users switch between the Connections and Status views while sharing the clock view model
- collapse the toolbar menu destinations into the new settings route while keeping existing control and digital font tabs intact

## Testing
- swift test *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ce23d8d9808330b1946a30db47d2b5